### PR TITLE
Add Settings header to distinguish function and content areas

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,23 +10,26 @@
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
-    <!-- Theme Toggle Button -->
-    <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
-        <svg class="sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <circle cx="12" cy="12" r="5"></circle>
-            <line x1="12" y1="1" x2="12" y2="3"></line>
-            <line x1="12" y1="21" x2="12" y2="23"></line>
-            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-            <line x1="1" y1="12" x2="3" y2="12"></line>
-            <line x1="21" y1="12" x2="23" y2="12"></line>
-            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-        </svg>
-        <svg class="moon-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-        </svg>
-    </button>
+    <!-- Settings Header -->
+    <div class="settings-header">
+        <h2 class="settings-title">Settings</h2>
+        <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
+            <svg class="sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <circle cx="12" cy="12" r="5"></circle>
+                <line x1="12" y1="1" x2="12" y2="3"></line>
+                <line x1="12" y1="21" x2="12" y2="23"></line>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                <line x1="1" y1="12" x2="3" y2="12"></line>
+                <line x1="21" y1="12" x2="23" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+            </svg>
+            <svg class="moon-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+        </button>
+    </div>
 
     <div class="container">
         <header>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -55,9 +55,29 @@ body {
     padding: 0;
 }
 
+/* Settings Header */
+.settings-header {
+    background: var(--surface);
+    border-bottom: 2px solid var(--border-color);
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+}
+
+.settings-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: 0;
+}
+
 /* Container - Full Screen */
 .container {
-    height: 100vh;
+    height: calc(100vh - 60px);
     width: 100vw;
     display: flex;
     flex-direction: column;
@@ -746,20 +766,16 @@ details[open] .suggested-header::before {
 
 /* Theme Toggle Button */
 .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    width: 48px;
-    height: 48px;
+    width: 40px;
+    height: 40px;
     border-radius: 50%;
-    background: var(--surface);
+    background: var(--background);
     border: 2px solid var(--border-color);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.3s ease;
-    z-index: 1000;
     box-shadow: var(--shadow);
 }
 
@@ -799,15 +815,25 @@ details[open] .suggested-header::before {
 }
 
 @media (max-width: 768px) {
+    .settings-header {
+        padding: 0.5rem 1rem;
+    }
+
+    .settings-title {
+        font-size: 0.75rem;
+    }
+
     .theme-toggle {
-        width: 44px;
-        height: 44px;
-        top: 0.75rem;
-        right: 0.75rem;
+        width: 36px;
+        height: 36px;
     }
 
     .theme-toggle svg {
         width: 20px;
         height: 20px;
+    }
+
+    .container {
+        height: calc(100vh - 50px);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a Settings header section to clearly distinguish the functional controls from the main application content.

## Changes
- Added a Settings header section above the main content
- Moved the theme toggle button into the settings header
- Updated CSS for clear visual separation between settings and content
- Adjusted responsive design for mobile devices

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)